### PR TITLE
ユーザー登録時、password_confirmationの項目を追加

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,2 +1,5 @@
-class Api::V1::Auth::RegistrationsController < ApplicationController
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  def sign_up_params
+    params.permit(:name, :email, :password, :password_confirmation)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  # mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {


### PR DESCRIPTION
# 概要
- deviseのコートローラーを修正
  - ユーザー登録時、password_confirmationの項目追加
  - passwordとpassword_confirmationが同じ値でないと登録できない。