### PR TITLE
deviseのコントローラーテスト実装

### DIFF
--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,7 +1,93 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "値が正しく入力されているとき" do
+      let(:params) { attributes_for(:user) }
+      it "ユーザー登録できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("success")
+        expect(res["data"]["id"]).to eq(User.last.id)
+        expect(res["data"]["email"]).to eq(User.last.email)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "password_confirmationの値がpasswordと異なるとき" do
+      let(:params) { attributes_for(:user, password_confirmation: "") }
+      it "ユーザー登録できない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("error")
+        expect(res["errors"]["full_messages"]).to include("Password confirmation doesn't match Password")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "POST /api/v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
+
+    context "メールアドレス、パスワードが正しいとき" do
+      let(:current_user) { create(:user) }
+      let(:params) { { email: current_user.email, password: current_user.password } }
+      it "ログインできる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response.headers["uid"]).to be_present
+        expect(response.headers["access-token"]).to be_present
+        expect(response.headers["client"]).to be_present
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "メールアドレスが正しくないとき" do
+      let(:current_user) { create(:user) }
+      let(:params) { { email: "test@example.com", password: current_user.password } }
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["success"]).to be_falsey
+        expect(res["errors"]).to include("Invalid login credentials. Please try again.")
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "パスワードが正しくないとき" do
+      let(:current_user) { create(:user) }
+      let(:params) { { email: current_user.email, password: "password" } }
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["success"]).to be_falsey
+        expect(res["errors"]).to include("Invalid login credentials. Please try again.")
+        expect(response.headers["uid"]).to be_blank
+        expect(response.headers["access-token"]).to be_blank
+        expect(response.headers["client"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+
+    context "ユーザーがログインしているとき" do
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
+      it "ログアウトできる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["success"]).to be_truthy
+        expect(current_user.reload.tokens).to be_blank
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end


### PR DESCRIPTION
# 概要
- ユーザーモデルのテスト実装
## テスト項目
1. ユーザー情報保存処理
- ユーザーが登録できること
  - response.body["status"] = "success"
  - response.body["data"]["id"] = 登録したユーザーid
  - response.body["data"]["email"] = 登録したユーザーemail
  - response.status = 200
- password_confirmationの値がpasswordと異なるときユーザー登録できない。
  - password_confirmationを空白で登録しようとする
  - response.body["status"] = "error"
  - エラーメッセージに"Password confirmation doesn't match Password"が含まれる。
  - response.status = 422
2. ログイン処理
- email、passwordが正しいとき、ログインできること
  - response.headers["uid"]が存在する
  - response.headers["access-token"]が存在する
  - response.headers["client"]が存在する
  - response.status = 200
- emailが正しくない場合、ログインできないこと
  - response.body["success"] = false
  - response.body["errors"]が想定したエラー文と等しい
  - response.headers["uid"]が空
  - response.headers["access-token"]が空
  - response.headers["client"]が空
  - response.status = 401
- passwordが正しくない場合、ログインできないこと
  - response.body["success"] = false
  - response.body["errors"]が想定したエラー文と等しい
  - response.headers["uid"]が空
  - response.headers["access-token"]が空
  - response.headers["client"]が空
  - response.status = 401
3. ログアウト処理
- ログインしているとき、ログアウトできること
  - response.body["success"] = true
  - カレントユーザーのreload.tokensが空であること
  - response.status = 200