### PR TITLE
create_new_auth_tokenを短縮する

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include SessionHelpers, type: :request
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,0 +1,6 @@
+module SessionHelpers
+  def auth_token(current_user)
+    current_user.create_new_auth_token
+  end
+end
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
# 概要
- `current_user.create_new_auth_token`という記述を`auth_token(current_user)`で読み込めるようにする。